### PR TITLE
Always returns a string instead of an array

### DIFF
--- a/Check/TableRowCount.php
+++ b/Check/TableRowCount.php
@@ -73,6 +73,8 @@ SQL
             }
         }
 
+        $messages = implode(', ', $messages);
+
         return $failure ? new Failure($messages) : new Success($messages);
     }
 }


### PR DESCRIPTION
To avoid an error `php bin/console monitor:health`

```php
[Symfony\Component\Debug\Exception\ContextErrorException]  
  Notice: Array to string conversion
```